### PR TITLE
Add the combination of Mobile Kinova + Leap Hand setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _build/
 _static/
 _templates/
 htmlcov/
+
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Examples:
+    - Mobile Kinova loaded from a module-oriented MJCF description: [mobile_kinova.py](examples/mobile_kinova.py)
+      - remove the nested class naming convention in the [tidybot.xml](tidybot.xml) file, allowing for seamless swapping of end-effectors.
+    - Mobile Kinova with LEAP hand: [mobile_kinova_leap.py](examples/mobile_kinova_leap.py)
+    - The example scripts also include updated recommendations for controlling the mobile base, aiming to minimize unnecessary rotation.
+
+### Added
+
+- Examples:
     - UFactory xArm7 with LEAP hand: [xarm_leap.py](examples/arm_hand_xarm_leap.py)
 
 ## [0.0.3] - 2024-08-10

--- a/examples/mobile_kinova.py
+++ b/examples/mobile_kinova.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+from dm_control.viewer import user_input
+from loop_rate_limiters import RateLimiter
+
+import mink
+
+_HERE = Path(__file__).parent
+_XML = _HERE / "stanford_tidybot" / "scene_mobile_kinova.xml"
+
+
+@dataclass
+class KeyCallback:
+    fix_base: bool = False
+    pause: bool = False
+
+    def __call__(self, key: int) -> None:
+        if key == user_input.KEY_ENTER:
+            self.fix_base = not self.fix_base
+        elif key == user_input.KEY_SPACE:
+            self.pause = not self.pause
+
+
+if __name__ == "__main__":
+    model = mujoco.MjModel.from_xml_path(_XML.as_posix())
+    data = mujoco.MjData(model)
+
+    # Joints we wish to control.
+    # fmt: off
+    joint_names = [
+        # Base joints.
+        "joint_x", "joint_y", "joint_th",
+        # Arm joints.
+        "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6", "joint_7",
+    ]
+    # fmt: on
+    dof_ids = np.array([model.joint(name).id for name in joint_names])
+    actuator_ids = np.array([model.actuator(name).id for name in joint_names])
+
+    configuration = mink.Configuration(model)
+
+    end_effector_task = mink.FrameTask(
+        frame_name="pinch_site",
+        frame_type="site",
+        position_cost=1.0,
+        orientation_cost=1.0,
+        lm_damping=1.0,
+    )
+
+    # When move the base, mainly focus on the motion on xy plane, minimize the rotation.
+    posture_cost = np.zeros((model.nv,))
+    posture_cost[2] = 1e-3
+    posture_task = mink.PostureTask(model, cost=posture_cost)
+
+    immobile_base_cost = np.zeros((model.nv,))
+    immobile_base_cost[:2] = 100
+    immobile_base_cost[2] = 1e-3
+    damping_task = mink.DampingTask(model, immobile_base_cost)
+
+    tasks = [
+        end_effector_task,
+        posture_task,
+    ]
+
+    limits = [
+        mink.ConfigurationLimit(model),
+    ]
+
+    # IK settings.
+    solver = "quadprog"
+    pos_threshold = 1e-4
+    ori_threshold = 1e-4
+    max_iters = 20
+
+    key_callback = KeyCallback()
+
+    with mujoco.viewer.launch_passive(
+        model=model,
+        data=data,
+        show_left_ui=False,
+        show_right_ui=False,
+        key_callback=key_callback,
+    ) as viewer:
+        mujoco.mjv_defaultFreeCamera(model, viewer.cam)
+
+        mujoco.mj_resetDataKeyframe(model, data, model.key("home").id)
+        configuration.update(data.qpos)
+        posture_task.set_target_from_configuration(configuration)
+        mujoco.mj_forward(model, data)
+
+        # Initialize the mocap target at the end-effector site.
+        mink.move_mocap_to_frame(model, data, "pinch_site_target", "pinch_site", "site")
+
+        rate = RateLimiter(frequency=200.0)
+        dt = rate.period
+        t = 0.0
+        while viewer.is_running():
+            # Update task target.
+            T_wt = mink.SE3.from_mocap_name(model, data, "pinch_site_target")
+            end_effector_task.set_target(T_wt)
+
+            # Compute velocity and integrate into the next configuration.
+            for i in range(max_iters):
+                if key_callback.fix_base:
+                    vel = mink.solve_ik(
+                        configuration, [*tasks, damping_task], rate.dt, solver, 1e-3
+                    )
+                else:
+                    vel = mink.solve_ik(configuration, tasks, rate.dt, solver, 1e-3)
+                configuration.integrate_inplace(vel, rate.dt)
+
+                # Exit condition.
+                pos_achieved = True
+                ori_achieved = True
+                err = end_effector_task.compute_error(configuration)
+                pos_achieved &= bool(np.linalg.norm(err[:3]) <= pos_threshold)
+                ori_achieved &= bool(np.linalg.norm(err[3:]) <= ori_threshold)
+                if pos_achieved and ori_achieved:
+                    break
+
+            if not key_callback.pause:
+                data.ctrl[actuator_ids] = configuration.q[dof_ids]
+                mujoco.mj_step(model, data)
+            else:
+                mujoco.mj_forward(model, data)
+
+            # Visualize at fixed FPS.
+            viewer.sync()
+            rate.sleep()
+            t += dt

--- a/examples/mobile_kinova_leap.py
+++ b/examples/mobile_kinova_leap.py
@@ -1,0 +1,217 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import mujoco
+import mujoco.viewer
+import numpy as np
+from dm_control import mjcf
+from dm_control.viewer import user_input
+from loop_rate_limiters import RateLimiter
+
+import mink
+
+_HERE = Path(__file__).parent
+_ARM_XML = _HERE / "stanford_tidybot" / "scene_mobile_kinova.xml"
+_HAND_XML = _HERE / "leap_hand" / "right_hand.xml"
+
+fingers = ["tip_1", "tip_2", "tip_3", "th_tip"]
+
+HOME_QPOS = [
+    # Mobile Base.
+    0, 0, 0,
+    # Kinova
+    0, 0.26179939, 3.14159265, -2.26892803, 0, 0.95993109, 1.57079633,
+    # Leap hand.
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+]
+
+
+def construct_model():
+    arm_mjcf = mjcf.from_path(_ARM_XML.as_posix())
+    arm_mjcf.find("key", "home").remove()
+    arm_mjcf.find("key", "retract").remove()
+
+    hand_mjcf = mjcf.from_path(_HAND_XML.as_posix())
+    palm = hand_mjcf.worldbody.find("body", "palm_lower")
+    palm.quat = (0, 0.707, 0.707, 0)
+    palm.pos = (0.03, 0.06, -0.0925)
+    attach_site = arm_mjcf.worldbody.find("site", "pinch_site")
+    attach_site.attach(hand_mjcf)
+
+    arm_mjcf.keyframe.add("key", name="home", qpos=HOME_QPOS)
+
+    for finger in fingers:
+        body = arm_mjcf.worldbody.add("body", name=f"{finger}_target", mocap=True)
+        body.add(
+            "geom",
+            type="sphere",
+            size=".02",
+            contype="0",
+            conaffinity="0",
+            rgba=".6 .3 .3 .5",
+        )
+
+    return mujoco.MjModel.from_xml_string(
+        arm_mjcf.to_xml_string(), arm_mjcf.get_assets()
+    )
+
+
+@dataclass
+class KeyCallback:
+    fix_base: bool = False
+    pause: bool = False
+
+    def __call__(self, key: int) -> None:
+        if key == user_input.KEY_ENTER:
+            self.fix_base = not self.fix_base
+        elif key == user_input.KEY_SPACE:
+            self.pause = not self.pause
+
+
+if __name__ == "__main__":
+    model = construct_model()
+
+    configuration = mink.Configuration(model)
+
+    end_effector_task = mink.FrameTask(
+        frame_name="pinch_site",
+        frame_type="site",
+        position_cost=1.0,
+        orientation_cost=1.0,
+        lm_damping=1.0,
+    )
+
+    # When move the base, mainly focus on the motion on xy plane, minimize the rotation.
+    posture_cost = np.zeros((model.nv,))
+    posture_cost[2] = 1e-3  # Mobile Base
+    # posture_cost[-16:] = 5e-2  # Leap Hand
+    posture_cost[-16:] = 1e-3  # Leap Hand
+
+    posture_task = mink.PostureTask(model, cost=posture_cost)
+
+    immobile_base_cost = np.zeros((model.nv,))
+    immobile_base_cost[:2] = 100
+    immobile_base_cost[2] = 1e-3
+    damping_task = mink.DampingTask(model, immobile_base_cost)
+
+
+    finger_tasks = []
+    for finger in fingers:
+        task = mink.RelativeFrameTask(
+            frame_name=f"leap_right/{finger}",
+            frame_type="site",
+            root_name="leap_right/palm_lower",
+            root_type="body",
+            position_cost=1.0,
+            orientation_cost=0.0,
+            lm_damping=1e-3,
+        )
+        finger_tasks.append(task)
+
+    tasks = [
+        end_effector_task,
+        posture_task,
+        *finger_tasks,
+    ]
+
+    limits = [
+        mink.ConfigurationLimit(model),
+    ]
+
+    # IK settings.
+    solver = "quadprog"
+    pos_threshold = 1e-4
+    ori_threshold = 1e-4
+    max_iters = 20
+    model = configuration.model
+    data = configuration.data
+
+    key_callback = KeyCallback()
+
+    with mujoco.viewer.launch_passive(
+        model=model,
+        data=data,
+        show_left_ui=False,
+        show_right_ui=False,
+        key_callback=key_callback,
+    ) as viewer:
+        mujoco.mjv_defaultFreeCamera(model, viewer.cam)
+
+        mujoco.mj_resetDataKeyframe(model, data, model.key("home").id)
+        configuration.update(data.qpos)
+        posture_task.set_target_from_configuration(configuration)
+        mujoco.mj_forward(model, data)
+
+        # Initialize the mocap target at the end-effector site.
+        mink.move_mocap_to_frame(model, data, "pinch_site_target", "pinch_site", "site")
+        for finger in fingers:
+            mink.move_mocap_to_frame(
+                model, data, f"{finger}_target", f"leap_right/{finger}", "site"
+            )
+
+        T_eef_prev = configuration.get_transform_frame_to_world(
+            "pinch_site", "site"
+        )
+
+        rate = RateLimiter(frequency=50.0)
+        dt = rate.period
+        t = 0.0
+        while viewer.is_running():
+            # Update task target.
+            T_wt = mink.SE3.from_mocap_name(model, data, "pinch_site_target")
+            end_effector_task.set_target(T_wt)
+
+            # Update finger tasks.
+            for finger, task in zip(fingers, finger_tasks):
+                T_pm = configuration.get_transform(
+                    f"{finger}_target", "body", "leap_right/palm_lower", "body"
+                )
+                task.set_target(T_pm)
+            
+
+            for finger in fingers:
+                T_eef = configuration.get_transform_frame_to_world("pinch_site", "site")
+                T = T_eef @ T_eef_prev.inverse()
+                T_w_mocap = mink.SE3.from_mocap_name(model, data, f"{finger}_target")
+                T_w_mocap_new = T @ T_w_mocap
+                data.mocap_pos[model.body(f"{finger}_target").mocapid[0]] = (
+                    T_w_mocap_new.translation()
+                )
+                data.mocap_quat[model.body(f"{finger}_target").mocapid[0]] = (
+                    T_w_mocap_new.rotation().wxyz
+                )
+
+            # Compute velocity and integrate into the next configuration.
+            for i in range(max_iters):
+                if key_callback.fix_base:
+                    vel = mink.solve_ik(
+                        configuration, [*tasks, damping_task], rate.dt, solver, 1e-3
+                    )
+                else:
+                    vel = mink.solve_ik(configuration, tasks, rate.dt, solver, 1e-3)
+                configuration.integrate_inplace(vel, rate.dt)
+
+                # Exit condition.
+                pos_achieved = True
+                ori_achieved = True
+                err = end_effector_task.compute_error(configuration)
+                pos_achieved &= bool(np.linalg.norm(err[:3]) <= pos_threshold)
+                ori_achieved &= bool(np.linalg.norm(err[3:]) <= ori_threshold)
+                if pos_achieved and ori_achieved:
+                    break
+
+            if not key_callback.pause:
+                data.ctrl = configuration.q
+                mujoco.mj_step(model, data)
+            else:
+                mujoco.mj_forward(model, data)
+            
+            T_eef_prev = T_eef.copy()
+
+            # Visualize at fixed FPS.
+            viewer.sync()
+            rate.sleep()
+            t += dt

--- a/examples/stanford_tidybot/README.md
+++ b/examples/stanford_tidybot/README.md
@@ -1,0 +1,8 @@
+# Tidybot and Mobile Kinova Description (MJCF)
+
+## Overview
+This package introduces a mobile manipulator developed by the [Interactive Perception and Robot Learning Lab](https://iprl.stanford.edu). The robot features a Kinova Gen 3 arm mounted on a holonomic base, which has been used in the well-known [Tidybot](https://tidybot.cs.princeton.edu) project for room tidying tasks. To expand the robot's functionality, the default 2F85 Robotiq gripper can be replaced with more dexterous hands, such as the [Leap Hand](https://leaphand.com/). The package provides a modular MJCF description of the mobile Kinova robot, enabling seamless swapping of end-effectors. Please note the nested class naming convention in the [tidybot.xml](tidybot.xml) file. For compatibility, this convention has been removed in the [mobile_kinova.xml](mobile_kinova.xml) file.
+
+## Exaples
+In the example script [mobile_tidybot.py](../mobile_tidybot.py), the robot equipped with the 2F85 Robotiq gripper is loaded from [tidybot.xml](tidybot.xml).
+In the example scripts [mobile_kinova.py](../mobile_kinova.py) and [mobile_kinova_leap.py](../mobile_kinova_leap.py), the mobile Kinova robot is loaded from [mobile_kinova.xml](mobile_kinova.xml). Both scripts also include updated recommendations for controlling the mobile base, aiming to minimize unnecessary rotation.

--- a/examples/stanford_tidybot/mobile_kinova.xml
+++ b/examples/stanford_tidybot/mobile_kinova.xml
@@ -1,0 +1,161 @@
+<mujoco model="tidybot">
+  <compiler angle="radian" meshdir="assets"/>
+
+  <option integrator="implicitfast"/>
+  <option cone="elliptic" impratio="10"/>
+
+  <default>
+    <default class="base">
+      <default class="base_visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2"/>
+      </default>
+      <default class="base_collision">
+        <geom type="mesh" group="3"/>
+      </default>
+    </default>
+
+    <default class="gen3">
+      <default class="gen3_visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2" rgba="0.75294 0.75294 0.75294 1"/>
+      </default>
+      <default class="gen3_collision">
+        <geom type="mesh" group="3"/>
+      </default>
+      <default class="large_actuator">
+        <position kp="2000" kv="100" forcerange="-105 105"/>
+      </default>
+      <default class="small_actuator">
+        <position kp="500" kv="50" forcerange="-52 52"/>
+      </default>
+    </default>
+    <site size="0.001" rgba="0.5 0.5 0.5 0.3" group="4"/>
+  </default>
+
+  <asset>
+    <material name="black" rgba="0.11372549 0.11372549 0.10196078 1"/>
+    <material name="gray" rgba="0.62745098 0.65098039 0.64705882 1"/>
+    <material name="dark_gray" rgba="0.35294118 0.37647059 0.37254902 1"/>
+    <mesh file="base/bumper.stl"/>
+    <mesh file="base/bottom_plate.stl"/>
+    <mesh file="base/body.stl"/>
+    <mesh file="base/top_plate.stl"/>
+    <mesh file="base/arm_plate.stl"/>
+
+    <mesh name="gen3_base_link" file="gen3/base_link.stl"/>
+    <mesh name="shoulder_link" file="gen3/shoulder_link.stl"/>
+    <mesh name="half_arm_1_link" file="gen3/half_arm_1_link.stl"/>
+    <mesh name="half_arm_2_link" file="gen3/half_arm_2_link.stl"/>
+    <mesh name="forearm_link" file="gen3/forearm_link.stl"/>
+    <mesh name="spherical_wrist_1_link" file="gen3/spherical_wrist_1_link.stl"/>
+    <mesh name="spherical_wrist_2_link" file="gen3/spherical_wrist_2_link.stl"/>
+    <mesh name="bracelet_with_vision_link" file="gen3/bracelet_with_vision_link.stl"/>
+
+    <material name="metal" rgba="0.58 0.58 0.58 1"/>
+    <material name="silicone" rgba="0.1882 0.1882 0.1882 1"/>
+  </asset>
+
+  <worldbody>
+    <body name="base_link">
+      <inertial pos="0 0 0.035" mass="60" diaginertia="0.001 0.001 0.001"/>
+      <joint name="joint_x" type="slide" axis="1 0 0"/>
+      <joint name="joint_y" type="slide" axis="0 1 0"/>
+      <joint name="joint_th"/>
+      <geom class="base_visual" mesh="bumper" material="black"/>
+      <geom class="base_visual" mesh="bottom_plate" material="dark_gray"/>
+      <geom class="base_visual" mesh="body" material="gray"/>
+      <geom class="base_visual" mesh="top_plate" material="dark_gray"/>
+      <geom class="base_visual" mesh="arm_plate" material="gray"/>
+      <geom class="base_collision" mesh="bumper"/>
+      <geom class="base_collision" mesh="bottom_plate"/>
+      <geom class="base_collision" mesh="body"/>
+      <geom class="base_collision" mesh="top_plate"/>
+      <geom class="base_collision" mesh="arm_plate"/>
+      <camera name="base" pos="0.2525 0 0.335" euler="0 -0.7853981634 -1.5707963268" fovy="52.23384539951277"
+        resolution="640 360"/>
+      <body name="gen3_base_link" pos="0 0 0.335" quat="1 0 0 0">
+        <inertial pos="-0.000648 -0.000166 0.084487" quat="0.999294 0.00139618 -0.0118387 0.035636" mass="1.697"
+          diaginertia="0.00462407 0.00449437 0.00207755"/>
+        <geom class="gen3_visual" mesh="gen3_base_link"/>
+        <geom class="gen3_collision" mesh="gen3_base_link"/>
+        <body name="shoulder_link" pos="0 0 0.15643" quat="0 1 0 0">
+          <inertial pos="-2.3e-05 -0.010364 -0.07336" quat="0.707051 0.0451246 -0.0453544 0.704263" mass="1.3773"
+            diaginertia="0.00488868 0.00457 0.00135132"/>
+          <joint name="joint_1"/>
+          <geom class="gen3_visual" mesh="shoulder_link"/>
+          <geom class="gen3_collision" mesh="shoulder_link"/>
+          <body name="half_arm_1_link" pos="0 0.005375 -0.12838" quat="1 1 0 0">
+            <inertial pos="-4.4e-05 -0.09958 -0.013278" quat="0.482348 0.516286 -0.516862 0.483366" mass="1.1636"
+              diaginertia="0.0113017 0.011088 0.00102532"/>
+            <joint name="joint_2" range="-2.24 2.24"/>
+            <geom class="gen3_visual" mesh="half_arm_1_link"/>
+            <geom class="gen3_collision" mesh="half_arm_1_link"/>
+            <body name="half_arm_2_link" pos="0 -0.21038 -0.006375" quat="1 -1 0 0">
+              <inertial pos="-4.4e-05 -0.006641 -0.117892" quat="0.706144 0.0213722 -0.0209128 0.707437" mass="1.1636"
+                diaginertia="0.0111633 0.010932 0.00100671"/>
+              <joint name="joint_3"/>
+              <geom class="gen3_visual" mesh="half_arm_2_link"/>
+              <geom class="gen3_collision" mesh="half_arm_2_link"/>
+              <body name="forearm_link" pos="0 0.006375 -0.21038" quat="1 1 0 0">
+                <inertial pos="-1.8e-05 -0.075478 -0.015006" quat="0.483678 0.515961 -0.515859 0.483455" mass="0.9302"
+                  diaginertia="0.00834839 0.008147 0.000598606"/>
+                <joint name="joint_4" range="-2.57 2.57"/>
+                <geom class="gen3_visual" mesh="forearm_link"/>
+                <geom class="gen3_collision" mesh="forearm_link"/>
+                <body name="spherical_wrist_1_link" pos="0 -0.20843 -0.006375" quat="1 -1 0 0">
+                  <inertial pos="1e-06 -0.009432 -0.063883" quat="0.703558 0.0707492 -0.0707492 0.703558" mass="0.6781"
+                    diaginertia="0.00165901 0.001596 0.000346988"/>
+                  <joint name="joint_5"/>
+                  <geom class="gen3_visual" mesh="spherical_wrist_1_link"/>
+                  <geom class="gen3_collision" mesh="spherical_wrist_1_link"/>
+                  <body name="spherical_wrist_2_link" pos="0 0.00017505 -0.10593" quat="1 1 0 0">
+                    <inertial pos="1e-06 -0.045483 -0.00965" quat="0.44426 0.550121 -0.550121 0.44426" mass="0.6781"
+                      diaginertia="0.00170087 0.001641 0.00035013"/>
+                    <joint name="joint_6" range="-2.09 2.09"/>
+                    <geom class="gen3_visual" mesh="spherical_wrist_2_link"/>
+                    <geom class="gen3_collision" mesh="spherical_wrist_2_link"/>
+                    <body name="bracelet_link" pos="0 -0.10593 -0.00017505" quat="1 -1 0 0">
+                      <inertial pos="0.000281 0.011402 -0.029798" quat="0.394358 0.596779 -0.577293 0.393789" mass="0.5"
+                        diaginertia="0.000657336 0.000587019 0.000320645"/>
+                      <joint name="joint_7"/>
+                      <geom class="gen3_visual" mesh="bracelet_with_vision_link"/>
+                      <geom class="gen3_collision" mesh="bracelet_with_vision_link"/>
+                      <camera name="wrist" pos="0 -0.05639 -0.058475" quat="0 0 0 1" fovy="41.83792730009236"
+                        resolution="640 480"/>           
+                      <site name="pinch_site" pos="0 0 -0.181525" quat="0 1 0 0"/>
+                    </body>
+                  </body>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <contact>
+  </contact>
+
+  <equality>
+  </equality>
+
+  <actuator>
+    <position name="joint_x" joint="joint_x" kp="1000000" kv="50000"/>
+    <position name="joint_y" joint="joint_y" kp="1000000" kv="50000"/>
+    <position name="joint_th" joint="joint_th" kp="50000" kv="1000"/>
+    <position class="large_actuator" name="joint_1" joint="joint_1"/>
+    <position class="large_actuator" name="joint_2" joint="joint_2" ctrlrange="-2.2497294058206907 2.2497294058206907"/>
+    <position class="large_actuator" name="joint_3" joint="joint_3"/>
+    <position class="large_actuator" name="joint_4" joint="joint_4" ctrlrange="-2.5795966344476193 2.5795966344476193"/>
+    <position class="small_actuator" name="joint_5" joint="joint_5"/>
+    <position class="small_actuator" name="joint_6" joint="joint_6" ctrlrange="-2.0996310901491784 2.0996310901491784"/>
+    <position class="small_actuator" name="joint_7" joint="joint_7"/>
+  </actuator>
+
+  <keyframe>
+    <key name="home" qpos="0 0 0 0 0.26179939 3.14159265 -2.26892803 0 0.95993109 1.57079633"
+      ctrl="0 0 0 0 0.26179939 3.14159265 -2.26892803 0 0.95993109 1.57079633"/>
+    <key name="retract" qpos="0 0 0 0 -0.34906585 3.14159265 -2.54818071 0 -0.87266463 1.57079633"
+      ctrl="0 0 0 0 -0.34906585 3.14159265 -2.54818071 0 -0.87266463 1.57079633"/>
+  </keyframe>
+</mujoco>

--- a/examples/stanford_tidybot/scene_mobile_kinova.xml
+++ b/examples/stanford_tidybot/scene_mobile_kinova.xml
@@ -1,0 +1,26 @@
+<mujoco model="mobile_kinova scene">
+  <include file="mobile_kinova.xml"/>
+
+  <statistic center="0.25 0 0.6" extent="1.0" meansize="0.05"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.1 0.1 0.1" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="120" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1.5" directional="true"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    <body name="pinch_site_target" pos="0.5 0 .5" quat="0 1 0 0" mocap="true">
+      <geom type="box" size=".05 .05 .05" contype="0" conaffinity="0" rgba=".6 .3 .3 .2"/>
+    </body>
+  </worldbody>
+</mujoco>


### PR DESCRIPTION
On the top of Stanford Tidybot equipped with 2F85 Robotiq gripper, I provide a modular MJCF description of Mobile Kinova robot, enabling seamless swapping of end-effectors. 
> Please note the nested class naming convention in the [tidybot.xml](https://github.com/kevinzakka/mink/blob/04d26c88e42c5124666231ca0bdf90150b3be8db/examples/stanford_tidybot/tidybot.xml#L9) file. For compatibility, this convention has been removed in the [mobile_kinova.xml](https://github.com/Zi-ang-Cao/MuJoCo-IKSolver/blob/36f5567575d1da54be11905e19e56172f7226799/examples/stanford_tidybot/mobile_kinova.xml#L9) file.

Additionally, I marry the Leap Hand with the Mobile Kinova platform in the example script [mobile_kinova_leap.py](https://github.com/Zi-ang-Cao/MuJoCo-IKSolver/blob/36f5567575d1da54be11905e19e56172f7226799/examples/mobile_kinova_leap.py#L96). This script also include updated recommendations for controlling the mobile base, aiming to minimize unnecessary rotation.


![Screenshot 2024-09-07 at 3 26 15 PM](https://github.com/user-attachments/assets/abc11631-da3d-493c-b1d6-b114caadaf48)
