### PR TITLE
Support for python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.7] - 2024-03-25
+
+### Changed
+
+- Added support for Python 3.8 by updating List and Tuple typing.
+
 ## [0.0.6] - 2025-03-15
 
 ### Added

--- a/examples/arm_aloha.py
+++ b/examples/arm_aloha.py
@@ -8,6 +8,7 @@ from loop_rate_limiters import RateLimiter
 
 import mink
 from mink.contrib import TeleopMocap
+from typing import List, Tuple
 
 _HERE = Path(__file__).parent
 _XML = _HERE / "aloha" / "scene.xml"
@@ -62,7 +63,7 @@ if __name__ == "__main__":
     right_subtree_id = model.body("right/base_link").id
 
     # Get the dof and actuator ids for the joints we wish to control.
-    joint_names: list[str] = []
+    joint_names: List[str] = []
     velocity_limits: dict[str, float] = {}
     for prefix in ["left", "right"]:
         for n in _JOINT_NAMES:

--- a/examples/arm_aloha.py
+++ b/examples/arm_aloha.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import mujoco
 import mujoco.viewer
@@ -8,7 +8,6 @@ from loop_rate_limiters import RateLimiter
 
 import mink
 from mink.contrib import TeleopMocap
-from typing import List, Tuple
 
 _HERE = Path(__file__).parent
 _XML = _HERE / "aloha" / "scene.xml"

--- a/mink/limits/collision_avoidance_limit.py
+++ b/mink/limits/collision_avoidance_limit.py
@@ -9,11 +9,12 @@ import numpy as np
 
 from ..configuration import Configuration
 from .limit import Constraint, Limit
+from typing import Tuple
 
 # Type aliases.
 Geom = Union[int, str]
 GeomSequence = Sequence[Geom]
-CollisionPair = tuple[GeomSequence, GeomSequence]
+CollisionPair = Tuple[GeomSequence, GeomSequence]
 CollisionPairs = Sequence[CollisionPair]
 
 
@@ -231,7 +232,7 @@ class CollisionAvoidanceLimit(Limit):
     def _homogenize_geom_id_list(self, geom_list: GeomSequence) -> List[int]:
         """Take a heterogeneous list of geoms (specified via ID or name) and return
         a homogenous list of IDs (int)."""
-        list_of_int: list[int] = []
+        list_of_int: List[int] = []
         for g in geom_list:
             if isinstance(g, int):
                 list_of_int.append(g)
@@ -245,8 +246,8 @@ class CollisionAvoidanceLimit(Limit):
         for collision_pair in collision_pairs:
             id_pair_A = self._homogenize_geom_id_list(collision_pair[0])
             id_pair_B = self._homogenize_geom_id_list(collision_pair[1])
-            id_pair_A = list(set(id_pair_A))
-            id_pair_B = list(set(id_pair_B))
+            id_pair_A = List(set(id_pair_A))
+            id_pair_B = List(set(id_pair_B))
             geom_id_pairs.append((id_pair_A, id_pair_B))
         return geom_id_pairs
 

--- a/mink/limits/collision_avoidance_limit.py
+++ b/mink/limits/collision_avoidance_limit.py
@@ -2,14 +2,13 @@
 
 import itertools
 from dataclasses import dataclass
-from typing import List, Sequence, Union
+from typing import List, Sequence, Tuple, Union
 
 import mujoco
 import numpy as np
 
 from ..configuration import Configuration
 from .limit import Constraint, Limit
-from typing import Tuple
 
 # Type aliases.
 Geom = Union[int, str]

--- a/mink/limits/configuration_limit.py
+++ b/mink/limits/configuration_limit.py
@@ -1,5 +1,7 @@
 """Joint position limit."""
 
+from typing import List
+
 import mujoco
 import numpy as np
 

--- a/mink/limits/configuration_limit.py
+++ b/mink/limits/configuration_limit.py
@@ -38,7 +38,7 @@ class ConfigurationLimit(Limit):
                 f"{self.__class__.__name__} gain must be in the range (0, 1]"
             )
 
-        index_list: list[int] = []  # DoF indices that are limited.
+        index_list: List[int] = []  # DoF indices that are limited.
         lower = np.full(model.nq, -mujoco.mjMAXVAL)
         upper = np.full(model.nq, mujoco.mjMAXVAL)
         for jnt in range(model.njnt):

--- a/mink/limits/velocity_limit.py
+++ b/mink/limits/velocity_limit.py
@@ -10,6 +10,7 @@ from ..configuration import Configuration
 from ..constants import dof_width
 from .exceptions import LimitDefinitionError
 from .limit import Constraint, Limit
+from typing import List, Tuple
 
 
 class VelocityLimit(Limit):
@@ -42,8 +43,8 @@ class VelocityLimit(Limit):
             velocities: Dictionary mapping joint name to maximum allowed magnitude in
                 [m]/[s] for slide joints and [rad]/[s] for hinge joints.
         """
-        limit_list: list[float] = []
-        index_list: list[int] = []
+        limit_list: List[float] = []
+        index_list: List[int] = []
         for joint_name, max_vel in velocities.items():
             jid = model.joint(joint_name).id
             jnt_type = model.jnt_type[jid]

--- a/mink/limits/velocity_limit.py
+++ b/mink/limits/velocity_limit.py
@@ -1,6 +1,6 @@
 """Joint velocity limit."""
 
-from typing import Mapping, Optional
+from typing import List, Mapping, Optional
 
 import mujoco
 import numpy as np
@@ -10,7 +10,6 @@ from ..configuration import Configuration
 from ..constants import dof_width
 from .exceptions import LimitDefinitionError
 from .limit import Constraint, Limit
-from typing import List, Tuple
 
 
 class VelocityLimit(Limit):

--- a/mink/solve_ik.py
+++ b/mink/solve_ik.py
@@ -1,6 +1,6 @@
 """Build and solve the inverse kinematics problem."""
 
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 import qpsolvers
@@ -9,7 +9,6 @@ from .configuration import Configuration
 from .limits import ConfigurationLimit, Limit
 from .tasks import Objective, Task
 
-from typing import List, Tuple
 
 def _compute_qp_objective(
     configuration: Configuration, tasks: Sequence[Task], damping: float

--- a/mink/solve_ik.py
+++ b/mink/solve_ik.py
@@ -9,6 +9,7 @@ from .configuration import Configuration
 from .limits import ConfigurationLimit, Limit
 from .tasks import Objective, Task
 
+from typing import List, Tuple
 
 def _compute_qp_objective(
     configuration: Configuration, tasks: Sequence[Task], damping: float
@@ -24,11 +25,11 @@ def _compute_qp_objective(
 
 def _compute_qp_inequalities(
     configuration: Configuration, limits: Optional[Sequence[Limit]], dt: float
-) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
     if limits is None:
         limits = [ConfigurationLimit(configuration.model)]
-    G_list: list[np.ndarray] = []
-    h_list: list[np.ndarray] = []
+    G_list: List[np.ndarray] = []
+    h_list: List[np.ndarray] = []
     for limit in limits:
         inequality = limit.compute_qp_inequalities(configuration, dt)
         if not inequality.inactive:

--- a/mink/tasks/equality_constraint_task.py
+++ b/mink/tasks/equality_constraint_task.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import mujoco
 import numpy as np
@@ -13,7 +13,6 @@ from ..configuration import Configuration
 from .exceptions import InvalidConstraint, TaskDefinitionError
 from .task import Task
 
-from typing import List, Tuple
 
 def _get_constraint_dim(constraint: int) -> int:
     """Return the dimension of an equality constraint in the efc* arrays."""

--- a/mink/tasks/equality_constraint_task.py
+++ b/mink/tasks/equality_constraint_task.py
@@ -13,6 +13,7 @@ from ..configuration import Configuration
 from .exceptions import InvalidConstraint, TaskDefinitionError
 from .task import Task
 
+from typing import List, Tuple
 
 def _get_constraint_dim(constraint: int) -> int:
     """Return the dimension of an equality constraint in the efc* arrays."""
@@ -169,7 +170,7 @@ class EqualityConstraintTask(Task):
     def _resolve_equality_ids(
         self, model: mujoco.MjModel, equalities: Optional[Sequence[int | str]]
     ) -> np.ndarray:
-        eq_ids: list[int] = []
+        eq_ids: List[int] = []
 
         if equalities is not None:
             for eq_id_or_name in equalities:

--- a/mink/utils.py
+++ b/mink/utils.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from . import constants as consts
 from .exceptions import InvalidKeyframe, InvalidMocapBody
+from typing import List, Tuple
 
 
 def move_mocap_to_frame(
@@ -35,7 +36,7 @@ def move_mocap_to_frame(
     mujoco.mju_mat2Quat(data.mocap_quat[mocap_id], xmat)
 
 
-def get_freejoint_dims(model: mujoco.MjModel) -> tuple[list[int], list[int]]:
+def get_freejoint_dims(model: mujoco.MjModel) -> Tuple[List[int], List[int]]:
     """Get all floating joint configuration and tangent indices.
 
     Args:
@@ -45,8 +46,8 @@ def get_freejoint_dims(model: mujoco.MjModel) -> tuple[list[int], list[int]]:
         A (q_ids, v_ids) pair containing all floating joint indices in the
         configuration and tangent spaces respectively.
     """
-    q_ids: list[int] = []
-    v_ids: list[int] = []
+    q_ids: List[int] = []
+    v_ids: List[int] = []
     for j in range(model.njnt):
         if model.jnt_type[j] == mujoco.mjtJoint.mjJNT_FREE:
             qadr = model.jnt_qposadr[j]
@@ -97,7 +98,7 @@ def custom_configuration_vector(
     return q
 
 
-def get_body_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
+def get_body_body_ids(model: mujoco.MjModel, body_id: int) -> List[int]:
     """Get immediate children bodies belonging to a given body.
 
     Args:
@@ -105,7 +106,7 @@ def get_body_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
         body_id: ID of body.
 
     Returns:
-        A list containing all child body ids.
+        A List containing all child body ids.
     """
     return [
         i
@@ -115,7 +116,7 @@ def get_body_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     ]
 
 
-def get_subtree_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
+def get_subtree_body_ids(model: mujoco.MjModel, body_id: int) -> List[int]:
     """Get all bodies belonging to subtree starting at a given body.
 
     Args:
@@ -123,9 +124,9 @@ def get_subtree_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
         body_id: ID of body where subtree starts.
 
     Returns:
-        A list containing all subtree body ids.
+        A List containing all subtree body ids.
     """
-    body_ids: list[int] = []
+    body_ids: List[int] = []
     stack = [body_id]
     while stack:
         body_id = stack.pop()
@@ -134,7 +135,7 @@ def get_subtree_body_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     return body_ids
 
 
-def get_body_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
+def get_body_geom_ids(model: mujoco.MjModel, body_id: int) -> List[int]:
     """Get immediate geoms belonging to a given body.
 
     Here, immediate geoms are those directly attached to the body and not its
@@ -152,7 +153,7 @@ def get_body_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     return list(range(geom_start, geom_end))
 
 
-def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
+def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> List[int]:
     """Get all geoms belonging to subtree starting at a given body.
 
     Here, a subtree is defined as the kinematic tree starting at the body and including
@@ -165,7 +166,7 @@ def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     Returns:
         A list containing all subtree geom ids.
     """
-    geom_ids: list[int] = []
+    geom_ids: List[int] = []
     stack = [body_id]
     while stack:
         body_id = stack.pop()

--- a/mink/utils.py
+++ b/mink/utils.py
@@ -1,11 +1,10 @@
-from typing import Optional
+from typing import List, Optional, Tuple
 
 import mujoco
 import numpy as np
 
 from . import constants as consts
 from .exceptions import InvalidKeyframe, InvalidMocapBody
-from typing import List, Tuple
 
 
 def move_mocap_to_frame(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 authors = [
     {name = "Kevin Zakka", email = "zakka@berkeley.edu"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dynamic = ["description"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/tests/test_equality_constraint_task.py
+++ b/tests/test_equality_constraint_task.py
@@ -90,7 +90,7 @@ class TestEqualityConstraintTask(absltest.TestCase):
         with self.assertRaises(InvalidConstraint) as cm:
             EqualityConstraintTask(model=model, cost=1.0, equalities=[5])
         expected_error_message = (
-            "Equality constraint index 5 out of range." "Must be in range [0, 4)."
+            "Equality constraint index 5 out of range.Must be in range [0, 4)."
         )
         self.assertEqual(str(cm.exception), expected_error_message)
 

--- a/tests/test_equality_constraint_task.py
+++ b/tests/test_equality_constraint_task.py
@@ -90,7 +90,7 @@ class TestEqualityConstraintTask(absltest.TestCase):
         with self.assertRaises(InvalidConstraint) as cm:
             EqualityConstraintTask(model=model, cost=1.0, equalities=[5])
         expected_error_message = (
-            "Equality constraint index 5 out of range.Must be in range [0, 4)."
+            "Equality constraint index 5 out of range. Must be in range [0, 4)."
         )
         self.assertEqual(str(cm.exception), expected_error_message)
 


### PR DESCRIPTION
**PR Description**
Changes the minimum python version to 3.8 instead of 3.9. This is helpful for compatibility with ROS1 or other code stuck in Ubuntu 20.04 land. 

**Key Changes**
- Changes python syntax to use List, Tuple from typing. 