### PR TITLE
Fix numerical stability issue in so3.py log function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Update so3.py log function to clamp quaternion values for arccos
+
 ## [0.0.9] - 2025-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update so3.py log function to clamp quaternion values for arccos
+- Update so3.py log function to use arctan2 instead of arccos for better numerical stability
 
 ## [0.0.9] - 2025-04-21
 

--- a/mink/lie/so3.py
+++ b/mink/lie/so3.py
@@ -169,15 +169,13 @@ class SO3(MatrixLieGroup):
 
     # Eq. 133.
     def log(self) -> np.ndarray:
-        w_clamped = np.clip(self.wxyz[0], -1.0, 1.0)
-        if w_clamped < 0.0:
-            theta = 2.0 * np.arccos(-w_clamped)
-            axis = -1.0 * np.array(self.wxyz[1:])
-        else:
-            theta = 2.0 * np.arccos(w_clamped)
-            axis = np.array(self.wxyz[1:])
-        mujoco.mju_normalize3(axis)
-        return theta * axis
+        q = np.array(self.wxyz)
+        q *= np.sign(q[0])
+        w, v = q[0], q[1:]
+        norm = mujoco.mju_normalize3(v)
+        if norm < get_epsilon(v.dtype):
+            return np.zeros_like(v)
+        return 2 * np.arctan2(norm, w) * v
 
     # Eq. 139.
     def adjoint(self) -> np.ndarray:

--- a/mink/lie/so3.py
+++ b/mink/lie/so3.py
@@ -169,11 +169,12 @@ class SO3(MatrixLieGroup):
 
     # Eq. 133.
     def log(self) -> np.ndarray:
-        if self.wxyz[0] < 0.0:
-            theta = 2.0 * np.arccos(-self.wxyz[0])
+        w_clamped = np.clip(self.wxyz[0], -1.0, 1.0)
+        if w_clamped < 0.0:
+            theta = 2.0 * np.arccos(-w_clamped)
             axis = -1.0 * np.array(self.wxyz[1:])
         else:
-            theta = 2.0 * np.arccos(self.wxyz[0])
+            theta = 2.0 * np.arccos(w_clamped)
             axis = np.array(self.wxyz[1:])
         mujoco.mju_normalize3(axis)
         return theta * axis


### PR DESCRIPTION
Hi,

I'm proposing a small fix in `so3.py` to resolve a numerical instability issue i encountered when controlling the ARX L5 robot arm with mink.

The original bug i was getting was:

```
/Users/jonzamora/miniforge3/envs/whirlsim/lib/python3.11/site-packages/mink/lie/so3.py:176: RuntimeWarning: invalid value encountered in arccos
  theta = 2.0 * np.arccos(self.wxyz[0])
WARNING: Nan, Inf or huge value in CTRL at ACTUATOR 0. The simulation is unstable. Time = 0.0000.
```

To fix this, I clamped `self.wxyz[0]` to the range (-1.0, 1.0). This ensures that the input to np.arccos() always remains within the mathematically valid range [-1,1].

After adding this fix, the arm works as intended (see below):

https://github.com/user-attachments/assets/35b2a546-97ec-49bc-9bcb-a4dc0d6d59c6

