### PR TITLE
Resolve locking force when objects are already in collision.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Bugfix
 
 - Fix `Configuration.get_inertia_matrix` for MuJoCo versions >= 3.3.4.
+- Objects already in collision repel each other instead of locking together.
 
 ## [0.0.11] - 2025-05-22
 

--- a/mink/limits/collision_avoidance_limit.py
+++ b/mink/limits/collision_avoidance_limit.py
@@ -206,7 +206,7 @@ class CollisionAvoidanceLimit(Limit):
             jac = compute_contact_normal_jacobian(
                 self.model, configuration.data, contact
             )
-            coefficient_matrix[idx] = -jac
+            coefficient_matrix[idx] = -np.sign(hi_bound_dist) * jac
         return Constraint(G=coefficient_matrix, h=upper_bound)
 
     # Private methods.


### PR DESCRIPTION
While it shouldn't typically happen, if collision objects have very small or no minimum distances there is a chance the objects can penetrate each other. If this happens, the direction of the Jacobian remains the same as before penetration but the sign changes. This means that the inequality constraint now enforces that that collision must remain in place.