### PR TITLE
Add reference to matrix Lie group numbered equations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ mink also heavily adapts code from the following libraries:
 
 * The lie algebra library that powers the transforms in mink is adapted from [jaxlie](https://github.com/brentyi/jaxlie).
 * The collision avoidance constraint is adapted from [dm_robotics](https://github.com/google-deepmind/dm_robotics/tree/main/cpp/controllers)'s LSQP controller.
+
+## References
+
+- The code implementing operations on matrix Lie groups contains references to numbered equations from the following paper: _[A micro lie theory for state estimation in robotics](https://arxiv.org/pdf/1812.01537), Joan Solà, Jeremie Deray, and Dinesh Atchuthan, arXiv preprint arXiv:1812.01537 (2018)_.


### PR DESCRIPTION
The code implementing operations on matrix Lie groups contains references to equations like:

```
# Eqn. 25.
def rplus(self, other: np.ndarray) -> Self:
    return self @ self.exp(other)

# Eqn. 26.
def rminus(self, other: Self) -> np.ndarray:
    return (other.inverse() @ self).log()

# Eq. 133.
def log(self) -> np.ndarray:
    q = np.array(self.wxyz)
    q *= np.sign(q[0])
    w, v = q[0], q[1:]
    norm = mujoco.mju_normalize3(v)
    if norm < get_epsilon(v.dtype):
        return np.zeros_like(v)
    return 2 * np.arctan2(norm, w) * v
```
However, there is no reference or link to the source of these numbered equations. This PR adds a reference to the [paper](https://arxiv.org/pdf/1812.01537) I think they're from (please correct me if I'm wrong).