### PR TITLE
feat: simplify `get_subtree_geom_ids`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `get_subtree_joint_ids` utility for retrieving all joints in the subtree rooted at a given body. Contribution from @maxstrobel.
+- `get_body_joint_ids` utility for retrieving immediate joints belonging to a given body. Contribution from @maxstrobel.
+
+### Changed
+
+- `get_subtree_geom_ids` and `get_subtree_joint_ids` now reuse `get_subtree_body_ids` instead of duplicating the traversal logic. Contribution from @maxstrobel.
 
 ### Fixed
 

--- a/src/mink/__init__.py
+++ b/src/mink/__init__.py
@@ -43,6 +43,7 @@ from .tasks import RelativeFrameTask as RelativeFrameTask
 from .tasks import Task as Task
 from .utils import custom_configuration_vector as custom_configuration_vector
 from .utils import get_body_geom_ids as get_body_geom_ids
+from .utils import get_body_joint_ids as get_body_joint_ids
 from .utils import get_freejoint_dims as get_freejoint_dims
 from .utils import get_subtree_body_ids as get_subtree_body_ids
 from .utils import get_subtree_geom_ids as get_subtree_geom_ids

--- a/src/mink/utils.py
+++ b/src/mink/utils.py
@@ -150,6 +150,26 @@ def get_body_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     return list(range(geom_start, geom_end))
 
 
+def get_body_joint_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
+    """Get immediate joints belonging to a given body.
+
+    Here, immediate joints are those directly attached to the body and not its
+    descendants.
+
+    Args:
+        model: Mujoco model.
+        body_id: ID of body.
+
+    Returns:
+        A list containing all body joint ids.
+    """
+    jnt_start = model.body_jntadr[body_id]
+    if jnt_start < 0:
+        return []
+    jnt_end = jnt_start + model.body_jntnum[body_id]
+    return list(range(jnt_start, jnt_end))
+
+
 def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     """Get all geoms belonging to subtree starting at a given body.
 
@@ -163,9 +183,10 @@ def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     Returns:
         A list containing all subtree geom ids.
     """
-    body_ids = set(get_subtree_body_ids(model, body_id))
     return [
-        geom_id for body_id in body_ids for geom_id in get_body_geom_ids(model, body_id)
+        geom_id
+        for bid in get_subtree_body_ids(model, body_id)
+        for geom_id in get_body_geom_ids(model, bid)
     ]
 
 
@@ -182,7 +203,8 @@ def get_subtree_joint_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     Returns:
         A list containing all subtree joint ids.
     """
-    body_ids = set(get_subtree_body_ids(model, body_id))
     return [
-        jnt_id for jnt_id in range(model.njnt) if model.jnt_bodyid[jnt_id] in body_ids
+        jnt_id
+        for bid in get_subtree_body_ids(model, body_id)
+        for jnt_id in get_body_joint_ids(model, bid)
     ]

--- a/src/mink/utils.py
+++ b/src/mink/utils.py
@@ -163,13 +163,10 @@ def get_subtree_geom_ids(model: mujoco.MjModel, body_id: int) -> list[int]:
     Returns:
         A list containing all subtree geom ids.
     """
-    geom_ids: list[int] = []
-    stack = [body_id]
-    while stack:
-        body_id = stack.pop()
-        geom_ids.extend(get_body_geom_ids(model, body_id))
-        stack += get_body_body_ids(model, body_id)
-    return geom_ids
+    body_ids = set(get_subtree_body_ids(model, body_id))
+    return [
+        geom_id for body_id in body_ids for geom_id in get_body_geom_ids(model, body_id)
+    ]
 
 
 def get_subtree_joint_ids(model: mujoco.MjModel, body_id: int) -> list[int]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,19 +142,19 @@ class TestUtils(absltest.TestCase):
         actual_geom_ids = utils.get_subtree_geom_ids(model, b1_id)
         geom_names = ["b1/g1", "b1/g2", "b2/g1"]
         expected_geom_ids = [model.geom(g).id for g in geom_names]
-        self.assertSetEqual(set(actual_geom_ids), set(expected_geom_ids))
+        self.assertListEqual(actual_geom_ids, expected_geom_ids)
         b3_id = model.body("b3").id
         actual_geom_ids = utils.get_subtree_geom_ids(model, b3_id)
         geom_names = ["b3/g1", "b4/g1"]
         expected_geom_ids = [model.geom(g).id for g in geom_names]
-        self.assertSetEqual(set(actual_geom_ids), set(expected_geom_ids))
+        self.assertListEqual(actual_geom_ids, expected_geom_ids)
         geomless_id = model.body("geomless").id
         actual_geom_ids = utils.get_subtree_geom_ids(model, geomless_id)
         self.assertListEqual(actual_geom_ids, [])
         world_id = 0
         actual_geom_ids = utils.get_subtree_geom_ids(model, world_id)
-        expected_geom_ids = [i for i in range(model.ngeom)]
-        self.assertSetEqual(set(actual_geom_ids), set(expected_geom_ids))
+        expected_geom_ids = set(range(model.ngeom))
+        self.assertSetEqual(set(actual_geom_ids), expected_geom_ids)
 
     def test_get_subtree_body_ids(self):
         xml_str = """
@@ -247,7 +247,7 @@ class TestUtils(absltest.TestCase):
             model.joint(n).id
             for n in ["b1/free", "b2/sx", "b2/sy", "b2/hz", "b2b/hinge"]
         ]
-        self.assertSetEqual(set(actual), set(expected))
+        self.assertListEqual(actual, expected)
         for n in ["b3/free", "b4/hinge"]:
             self.assertNotIn(model.joint(n).id, actual)
 
@@ -255,14 +255,14 @@ class TestUtils(absltest.TestCase):
         b2_id = model.body("b2").id
         actual = utils.get_subtree_joint_ids(model, b2_id)
         expected = [model.joint(n).id for n in ["b2/sx", "b2/sy", "b2/hz", "b2b/hinge"]]
-        self.assertSetEqual(set(actual), set(expected))
+        self.assertListEqual(actual, expected)
         self.assertNotIn(model.joint("b1/free").id, actual)
 
         # Sibling subtree.
         b3_id = model.body("b3").id
         actual = utils.get_subtree_joint_ids(model, b3_id)
         expected = [model.joint(n).id for n in ["b3/free", "b4/hinge"]]
-        self.assertSetEqual(set(actual), set(expected))
+        self.assertListEqual(actual, expected)
 
         # Body with no joint anywhere in its subtree.
         jointless_id = model.body("jointless").id
@@ -272,6 +272,46 @@ class TestUtils(absltest.TestCase):
         world_id = 0
         actual = utils.get_subtree_joint_ids(model, world_id)
         self.assertSetEqual(set(actual), set(range(model.njnt)))
+
+    def test_get_body_joint_ids(self):
+        xml_str = """
+        <mujoco>
+          <worldbody>
+            <body name="b1" pos=".1 -.1 0">
+              <joint type="slide" name="b1/sx" axis="1 0 0"/>
+              <joint type="slide" name="b1/sy" axis="0 1 0"/>
+              <joint type="hinge" name="b1/hz" axis="0 0 1"/>
+              <geom name="b1/g1" type="sphere" size=".1" mass=".1"/>
+              <body name="b2">
+                <joint type="hinge" name="b2/hinge"/>
+                <geom name="b2/g1" type="sphere" size=".1" mass=".1"/>
+              </body>
+            </body>
+            <body name="jointless">
+              <inertial pos="0 0 0" mass=".1" diaginertia="1 1 1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        model = mujoco.MjModel.from_xml_string(xml_str)
+
+        # Body with multiple joints.
+        b1_id = model.body("b1").id
+        actual = utils.get_body_joint_ids(model, b1_id)
+        expected = [model.joint(n).id for n in ["b1/sx", "b1/sy", "b1/hz"]]
+        self.assertListEqual(actual, expected)
+
+        # Body with a single joint.
+        b2_id = model.body("b2").id
+        actual = utils.get_body_joint_ids(model, b2_id)
+        self.assertListEqual(actual, [model.joint("b2/hinge").id])
+
+        # Body with no joints.
+        jointless_id = model.body("jointless").id
+        self.assertListEqual(utils.get_body_joint_ids(model, jointless_id), [])
+
+        # World body has no joints.
+        self.assertListEqual(utils.get_body_joint_ids(model, 0), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reuse logic from `get_subtree_body_ids` to simplify `get_subtree_geom_ids`.