### PR TITLE
Fuse QP objective assembly in solve_ik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `CollisionAvoidanceLimit`: added a bounding-sphere/plane broadphase that skips geom pairs out of `collision_detection_distance` range before the narrow-phase `mj_geomDistance` query, mirroring MuJoCo's `mj_filterSphere`. The assembled constraint is unchanged. ~2.9x faster collision phase, ~3.3x faster end-to-end IK on the ALOHA dual-arm scene (M1 Max). Disable with `broadphase=False`.
+- `solve_ik` / `build_ik`: fused the QP objective assembly. Tasks now expose a weighted least-squares residual (`Task.compute_qp_residual`) that the solver stacks into a single `WᵀW` matmul instead of summing per-task Hessians, and `Configuration` caches resolved frame ids. ~1.3x faster end-to-end IK on the G1 humanoid (8 tasks), scaling with task count (~1.4x on a 21-task hand, M1 Max). The assembled objective is unchanged up to floating-point summation order.
 
 ## [1.1.1] - 2026-05-15
 

--- a/src/mink/configuration.py
+++ b/src/mink/configuration.py
@@ -68,6 +68,9 @@ class Configuration:
         # Cached identity matrix for QP assembly.
         self._eye_nv = np.eye(model.nv)
 
+        # Cache of resolved frame ids; these are static for a given model.
+        self._frame_id_cache: dict[tuple[str, str], int] = {}
+
         self.update(q=q)
 
     def update(self, q: np.ndarray | None = None) -> None:
@@ -175,7 +178,11 @@ class Configuration:
         return jac
 
     def _resolve_frame_id(self, frame_name: str, frame_type: str) -> int:
-        """Validate frame type and resolve name to ID."""
+        """Validate frame type and resolve name to ID (cached; ids are static)."""
+        key = (frame_name, frame_type)
+        cached = self._frame_id_cache.get(key)
+        if cached is not None:
+            return cached
         if frame_type not in consts.SUPPORTED_FRAMES:
             raise exceptions.UnsupportedFrame(frame_type, consts.SUPPORTED_FRAMES)
         frame_id = mujoco.mj_name2id(
@@ -187,6 +194,7 @@ class Configuration:
                 frame_type=frame_type,
                 model=self.model,
             )
+        self._frame_id_cache[key] = frame_id
         return frame_id
 
     def _get_transform_frame_to_world_wxyz_xyz(

--- a/src/mink/solve_ik.py
+++ b/src/mink/solve_ik.py
@@ -14,12 +14,49 @@ from .tasks import BaseTask, Objective, Task
 def _compute_qp_objective(
     configuration: Configuration, tasks: Sequence[BaseTask], damping: float
 ) -> Objective:
-    H = np.eye(configuration.model.nv) * damping
-    c = np.zeros(configuration.model.nv)
+    r"""Assemble the QP objective :math:`(H, c)` from all tasks.
+
+    Tasks whose Hessian has the low-rank form :math:`J^T J` expose a weighted
+    residual :math:`(W_i, e_i, \mu_i)`; stacking the :math:`W_i` lets us compute
+    :math:`\sum_i W_i^T W_i = W^T W` with a single matrix multiply rather than
+    summing per-task Hessians. Per-task Levenberg-Marquardt terms :math:`\mu_i`
+    sum into the diagonal alongside the global ``damping``. Any task that returns
+    no residual (e.g. an inertia-weighted Hessian) is added densely.
+    """
+    nv = configuration.model.nv
+
+    weighted_jacobians: list[np.ndarray] = []
+    weighted_errors: list[np.ndarray] = []
+    mu_total = 0.0
+    H_dense: np.ndarray | None = None
+    c_dense: np.ndarray | None = None
     for task in tasks:
-        H_task, c_task = task.compute_qp_objective(configuration)
-        H += H_task
-        c += c_task
+        residual = task.compute_qp_residual(configuration)
+        if residual is None:
+            H_task, c_task = task.compute_qp_objective(configuration)
+            H_dense = H_task if H_dense is None else H_dense + H_task
+            c_dense = c_task if c_dense is None else c_dense + c_task
+        else:
+            weighted_jacobian, weighted_error, mu = residual
+            weighted_jacobians.append(weighted_jacobian)
+            weighted_errors.append(weighted_error)
+            mu_total += mu
+
+    if weighted_jacobians:
+        W = np.vstack(weighted_jacobians)
+        H = W.T @ W
+        c = -(np.concatenate(weighted_errors) @ W)
+    else:
+        H = np.zeros((nv, nv))
+        c = np.zeros(nv)
+
+    # Global LM damping plus the summed per-task LM terms on the diagonal.
+    H.flat[:: nv + 1] += damping + mu_total
+
+    if H_dense is not None:
+        assert c_dense is not None  # Set together with H_dense.
+        H += H_dense
+        c += c_dense
     return Objective(H, c)
 
 

--- a/src/mink/tasks/frame_task.py
+++ b/src/mink/tasks/frame_task.py
@@ -176,12 +176,11 @@ class FrameTask(Task):
         T_tb = SE3(wxyz_xyz=target).inverse() @ SE3(wxyz_xyz=frame)
         return -T_tb.jlog() @ jac
 
-    def compute_qp_objective(self, configuration: Configuration) -> Objective:
-        r"""Compute the matrix-vector pair :math:`(H, c)` of the QP objective.
-
-        Overrides the base implementation to compute the frame transform once
-        and reuse it for both error and Jacobian computation.
-        """
+    def _error_and_jacobian(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Compute the task error and Jacobian together, sharing the frame
+        transform (which both depend on) so it is only fetched once."""
         if self.transform_target_to_world is None:
             raise TargetNotSet(self.__class__.__name__)
 
@@ -202,4 +201,19 @@ class FrameTask(Task):
             T_tb = target_se3.inverse() @ frame_se3
             jacobian = -T_tb.jlog() @ jac
 
+        return error, jacobian
+
+    def compute_qp_objective(self, configuration: Configuration) -> Objective:
+        r"""Compute the matrix-vector pair :math:`(H, c)` of the QP objective.
+
+        Overrides the base implementation to compute the frame transform once
+        and reuse it for both error and Jacobian computation.
+        """
+        error, jacobian = self._error_and_jacobian(configuration)
         return self._assemble_qp(error, jacobian, configuration._eye_nv)
+
+    def compute_qp_residual(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        error, jacobian = self._error_and_jacobian(configuration)
+        return self._weighted_residual(error, jacobian)

--- a/src/mink/tasks/relative_frame_task.py
+++ b/src/mink/tasks/relative_frame_task.py
@@ -152,11 +152,11 @@ class RelativeFrameTask(Task):
                 - frame_se3.inverse().adjoint() @ jacobian_root_in_root
             )
 
-    def compute_qp_objective(self, configuration: Configuration) -> Objective:
-        r"""Compute the matrix-vector pair :math:`(H, c)` of the QP objective.
-
-        Overrides the base implementation to compute shared quantities once.
-        """
+    def _error_and_jacobian(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Compute the task error and Jacobian together, sharing the relative
+        transform and frame Jacobians that both depend on."""
         if self.transform_target_to_root is None:
             raise TargetNotSet(self.__class__.__name__)
 
@@ -188,4 +188,18 @@ class RelativeFrameTask(Task):
                 - frame_se3.inverse().adjoint() @ jacobian_root_in_root
             )
 
+        return error, jacobian
+
+    def compute_qp_objective(self, configuration: Configuration) -> Objective:
+        r"""Compute the matrix-vector pair :math:`(H, c)` of the QP objective.
+
+        Overrides the base implementation to compute shared quantities once.
+        """
+        error, jacobian = self._error_and_jacobian(configuration)
         return self._assemble_qp(error, jacobian, configuration._eye_nv)
+
+    def compute_qp_residual(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        error, jacobian = self._error_and_jacobian(configuration)
+        return self._weighted_residual(error, jacobian)

--- a/src/mink/tasks/task.py
+++ b/src/mink/tasks/task.py
@@ -39,6 +39,23 @@ class BaseTask(abc.ABC):
         """
         raise NotImplementedError
 
+    def compute_qp_residual(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray, float] | None:
+        r"""Return this task's weighted least-squares residual, if it has one.
+
+        A task whose Hessian contribution has the low-rank form :math:`J^T J` can
+        return the triple ``(weighted_jacobian, weighted_error, mu)``, letting the
+        solver fuse all tasks into a single :math:`W^T W` instead of summing per-task
+        :math:`n_v \times n_v` Hessians. ``mu`` is the scalar Levenberg-Marquardt
+        term that gets added to the diagonal.
+
+        Returns ``None`` (the default) for tasks whose objective is not of this form
+        (e.g. an inertia-weighted Hessian); those fall back to
+        :meth:`compute_qp_objective`.
+        """
+        return None
+
 
 class Task(BaseTask):
     r"""Abstract base class for kinematic tasks.
@@ -120,6 +137,15 @@ class Task(BaseTask):
         """
         raise NotImplementedError
 
+    def _weighted_residual(
+        self, error: np.ndarray, jacobian: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """Cost-weighted Jacobian, cost-weighted error, and scalar LM term."""
+        weighted_error = self.cost * (-self.gain * error)
+        weighted_jacobian = self.cost[:, None] * jacobian
+        mu = self.lm_damping * float(weighted_error @ weighted_error)
+        return weighted_jacobian, weighted_error, mu
+
     def _assemble_qp(
         self,
         error: np.ndarray,
@@ -127,9 +153,7 @@ class Task(BaseTask):
         eye_nv: np.ndarray,
     ) -> Objective:
         """Assemble QP objective from task error and Jacobian."""
-        weighted_error = self.cost * (-self.gain * error)
-        weighted_jacobian = self.cost[:, None] * jacobian
-        mu = self.lm_damping * (weighted_error @ weighted_error)
+        weighted_jacobian, weighted_error, mu = self._weighted_residual(error, jacobian)
         H = weighted_jacobian.T @ weighted_jacobian
         if mu > 0.0:
             H = H + mu * eye_nv
@@ -160,4 +184,14 @@ class Task(BaseTask):
             self.compute_error(configuration),
             self.compute_jacobian(configuration),
             configuration._eye_nv,
+        )
+
+    def compute_qp_residual(
+        self, configuration: Configuration
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """Weighted residual from the generic error/Jacobian path. See
+        :meth:`BaseTask.compute_qp_residual`."""
+        return self._weighted_residual(
+            self.compute_error(configuration),
+            self.compute_jacobian(configuration),
         )

--- a/tests/test_solve_ik.py
+++ b/tests/test_solve_ik.py
@@ -1,5 +1,7 @@
 """Tests for solve_ik.py."""
 
+from typing import cast
+
 import numpy as np
 from absl.testing import absltest
 from numpy.linalg import norm
@@ -70,6 +72,57 @@ class TestSolveIK(absltest.TestCase):
         problem = mink.build_ik(self.configuration, [], dt=1.0)
         self.assertIsNotNone(problem.G)
         self.assertIsNotNone(problem.h)
+
+    def test_fused_objective_matches_per_task_sum(self):
+        """The fused QP objective equals the naive per-task sum, across a frame,
+        posture, and relative-frame task (all fused) plus a task that uses the
+        dense fallback (KineticEnergyRegularizationTask, whose Hessian is
+        inertia-weighted rather than J^T J)."""
+        self.configuration.update_from_keyframe("home")
+        frame_task = mink.FrameTask(
+            "attachment_site",
+            "site",
+            position_cost=1.0,
+            orientation_cost=1.0,
+            lm_damping=1e-2,
+        )
+        frame_task.set_target_from_configuration(self.configuration)
+        posture_task = mink.PostureTask(self.model, cost=1e-1, lm_damping=1e-3)
+        posture_task.set_target_from_configuration(self.configuration)
+        relative_task = mink.RelativeFrameTask(
+            "attachment_site",
+            "site",
+            root_name="upper_arm_link",
+            root_type="body",
+            position_cost=1.0,
+            orientation_cost=1.0,
+            lm_damping=1e-3,
+        )
+        relative_task.set_target_from_configuration(self.configuration)
+        ke_task = mink.KineticEnergyRegularizationTask(cost=1e-4)
+        ke_task.set_dt(0.02)
+        tasks = [frame_task, posture_task, relative_task, ke_task]
+
+        # Perturb so the task errors (and hence the LM terms) are non-zero.
+        q = self.model.key("home").qpos.copy()
+        q[:3] += 0.2
+        self.configuration.update(q)
+
+        damping = 1e-6
+        problem = mink.build_ik(self.configuration, tasks, dt=0.02, damping=damping)
+
+        nv = self.model.nv
+        H = np.eye(nv) * damping
+        c = np.zeros(nv)
+        for task in tasks:
+            obj = task.compute_qp_objective(self.configuration)
+            H += obj.H
+            c += obj.c
+
+        # P is typed ndarray|csc_matrix but is dense here; q is already ndarray.
+        P = cast(np.ndarray, problem.P)
+        np.testing.assert_allclose(P, H, rtol=1e-9, atol=1e-12)
+        np.testing.assert_allclose(problem.q, c, rtol=1e-9, atol=1e-12)
 
     def test_trivial_solution(self):
         """No task returns no velocity."""


### PR DESCRIPTION
This PR stacks every task's Jacobian into one matrix and forms the Hessian with a single `Wᵀ W`, rather than computing and adding `Jᵀ J` for each task one at a time. On an M1 Max this gives a ~1.3–1.4× end-to-end speedup when many tasks are active. The gain comes from fewer Python/NumPy calls (one large matrix multiply instead of many tiny ones).
