### PR TITLE
Deploy docs with GitHub Actions instead of the gh-pages branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Run lint
         run: uvx ruff@0.14.7 check --diff
       - name: Run format
@@ -46,6 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Test with python ${{ matrix.python-version }}
         run: uv run pyright
 
@@ -62,6 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Test with python ${{ matrix.python-version }}
         run: uv run ty check
 
@@ -78,6 +81,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Test with python ${{ matrix.python-version }}
         run: uv run pytest
 
@@ -91,6 +95,7 @@ jobs:
           python-version: "3.13"
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Build wheel and sdist
         run: uv build
 
@@ -104,6 +109,7 @@ jobs:
           python-version: "3.13"
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: ${{ github.job }}
       - name: Run coverage
         run: uv run coverage run --source=src -m pytest .
       - name: Coveralls

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,18 @@ on:
 env:
   UV_FROZEN: "1"
 
+permissions:
+  contents: read
+
+# Allow one concurrent deployment, without cancelling in-progress runs.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  docs:
-    name: "GitHub Pages"
+  build:
+    name: Build docs
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup uv
@@ -23,13 +29,27 @@ jobs:
           python-version: "3.13"
           enable-cache: true
           version: "0.9.14"
+          cache-suffix: docs
       - name: Build documentation
         run: uv run --group doc sphinx-build docs _build -W
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+      - name: Upload Pages artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          force_orphan: true
+          path: _build/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Switches the docs deploy from the old gh-pages branch to GitHub's Actions-based Pages flow. This drops the leftover Node 20 warning, which came from GitHub's own builder for branch-based Pages.

Also adds a per-job cache key so the parallel jobs stop fighting over the same cache.