### PR TITLE
Execute documentation examples in CI to prevent API drift.

### DIFF
--- a/docs/tutorial/quickstart.rst
+++ b/docs/tutorial/quickstart.rst
@@ -164,48 +164,8 @@ joints.
 Complete Example
 ================
 
-.. code:: python
-
-   import mujoco
-   import numpy as np
-
-   from mink import Configuration, FrameTask, SE3, SO3, solve_ik
-
-   # Load robot.
-   model = mujoco.MjModel.from_xml_path("franka_emika_panda/mjx_scene.xml")
-   configuration = Configuration(model)
-   configuration.update_from_keyframe("home")
-
-   # Define target pose relative to current end-effector.
-   ee_pose = configuration.get_transform_frame_to_world("attachment_site", "site")
-   translation = np.array([0.0, -0.4, -0.2])
-   rotation = SO3.from_y_radians(-np.pi / 2)
-   target = SE3.from_translation(translation) @ ee_pose
-   target = target @ SE3.from_rotation(rotation)
-
-   # Create task with gain for smooth 2-second convergence.
-   duration, fps = 2.0, 60
-   n_frames = int(duration * fps)
-   gain = 1.0 - 0.01 ** (1.0 / n_frames)
-
-   task = FrameTask(
-       frame_name="attachment_site",
-       frame_type="site",
-       position_cost=1.0,
-       orientation_cost=1.0,
-       gain=gain,
-   )
-   task.set_target(target)
-
-   # Run IK loop.
-   dt = 1.0 / fps
-   for _ in range(n_frames):
-       vel = solve_ik(configuration, [task], dt, "daqp")
-       configuration.integrate_inplace(vel, dt)
-
-   # Check result.
-   final = configuration.get_transform_frame_to_world("attachment_site", "site")
-   print(f"Position error: {np.linalg.norm(final.translation() - target.translation()):.2e} m")
+.. literalinclude:: ../../examples/docs/quickstart.py
+   :language: python
 
 Next Steps
 ==========

--- a/docs/tutorial/tasks_and_limits.rst
+++ b/docs/tutorial/tasks_and_limits.rst
@@ -303,52 +303,8 @@ Complete Example
 
 The following example combines pose tracking with regularization and limits.
 
-.. code:: python
-
-   import mujoco
-   from mink import (
-       Configuration,
-       ConfigurationLimit,
-       FrameTask,
-       PostureTask,
-       VelocityLimit,
-       solve_ik,
-   )
-
-   # Load and configure.
-   model = mujoco.MjModel.from_xml_path("franka_emika_panda/mjx_scene.xml")
-   configuration = Configuration(model)
-   configuration.update_from_keyframe("home")
-
-   # Primary task: pose tracking.
-   task = FrameTask(
-       frame_name="attachment_site",
-       frame_type="site",
-       position_cost=1.0,
-       orientation_cost=1.0,
-   )
-
-   # Regularization: bias toward home configuration.
-   # This handles both singularities (resists extreme velocities near them)
-   # and nullspace drift (fills unused DOFs with a preference).
-   posture_task = PostureTask(model, cost=0.1)
-   posture_task.set_target_from_configuration(configuration)
-
-   tasks = [task, posture_task]
-
-   # Limits: joint bounds + velocity cap.
-   velocity_limits = {f"joint{i}": 2.0 for i in range(1, 8)}
-   limits = [
-       ConfigurationLimit(model),
-       VelocityLimit(model, velocity_limits),
-   ]
-
-   # IK loop.
-   dt = 0.01
-   for _ in range(steps):
-       task.set_target(get_target())  # Update target each step.
-       vel = solve_ik(configuration, tasks, dt, "daqp", limits=limits)
-       configuration.integrate_inplace(vel, dt)
+.. literalinclude:: ../../examples/docs/tasks_and_limits.py
+   :language: python
 
 Next Steps
 ==========

--- a/examples/docs/quickstart.py
+++ b/examples/docs/quickstart.py
@@ -1,0 +1,42 @@
+import mujoco
+import numpy as np
+
+from mink import SE3, SO3, Configuration, FrameTask, solve_ik
+
+# Load robot.
+model = mujoco.MjModel.from_xml_path("franka_emika_panda/mjx_scene.xml")
+configuration = Configuration(model)
+configuration.update_from_keyframe("home")
+
+# Define target pose relative to current end-effector.
+ee_pose = configuration.get_transform_frame_to_world("attachment_site", "site")
+translation = np.array([0.0, -0.4, -0.2])
+rotation = SO3.from_y_radians(-np.pi / 2)
+target = SE3.from_translation(translation) @ ee_pose
+target = target @ SE3.from_rotation(rotation)
+
+# Create task with gain for smooth 2-second convergence.
+duration, fps = 2.0, 60
+n_frames = int(duration * fps)
+gain = 1.0 - 0.01 ** (1.0 / n_frames)
+
+task = FrameTask(
+    frame_name="attachment_site",
+    frame_type="site",
+    position_cost=1.0,
+    orientation_cost=1.0,
+    gain=gain,
+)
+task.set_target(target)
+
+# Run IK loop.
+dt = 1.0 / fps
+for _ in range(n_frames):
+    vel = solve_ik(configuration, [task], dt, "daqp")
+    configuration.integrate_inplace(vel, dt)
+
+# Check result.
+final = configuration.get_transform_frame_to_world("attachment_site", "site")
+print(
+    f"Position error: {np.linalg.norm(final.translation() - target.translation()):.2e} m"
+)

--- a/examples/docs/tasks_and_limits.py
+++ b/examples/docs/tasks_and_limits.py
@@ -1,0 +1,53 @@
+import mujoco
+import numpy as np
+
+from mink import (
+    SE3,
+    Configuration,
+    ConfigurationLimit,
+    FrameTask,
+    PostureTask,
+    VelocityLimit,
+    solve_ik,
+)
+
+# Load and configure.
+model = mujoco.MjModel.from_xml_path("franka_emika_panda/mjx_scene.xml")
+configuration = Configuration(model)
+configuration.update_from_keyframe("home")
+
+# Primary task: pose tracking.
+task = FrameTask(
+    frame_name="attachment_site",
+    frame_type="site",
+    position_cost=1.0,
+    orientation_cost=1.0,
+)
+
+# Regularization: bias toward home configuration.
+# This handles both singularities (resists extreme velocities near them)
+# and nullspace drift (fills unused DOFs with a preference).
+posture_task = PostureTask(model, cost=0.1)
+posture_task.set_target_from_configuration(configuration)
+
+tasks = [task, posture_task]
+
+# Limits: joint bounds + velocity cap.
+velocity_limits = {f"joint{i}": 2.0 for i in range(1, 8)}
+limits = [
+    ConfigurationLimit(model),
+    VelocityLimit(model, velocity_limits),
+]
+
+# IK loop: track a target that traces a small circle in front of the arm.
+home_pose = configuration.get_transform_frame_to_world("attachment_site", "site")
+dt = 0.01
+steps = 200
+for step in range(steps):
+    angle = 2.0 * np.pi * step / steps
+    offset = np.array([0.0, 0.1 * np.cos(angle), 0.1 * np.sin(angle)])
+    task.set_target(
+        SE3.from_translation(offset) @ home_pose
+    )  # Update target each step.
+    vel = solve_ik(configuration, tasks, dt, "daqp", limits=limits)
+    configuration.integrate_inplace(vel, dt)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,39 @@
+"""Execute the runnable code examples embedded in the documentation.
+
+Each fixture under ``examples/docs/`` is the single source of truth for a
+``literalinclude`` block in the docs. Running them here ensures the documented
+code stays in sync with the public API.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from absl.testing import absltest, parameterized
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+_DOC_EXAMPLES = sorted((_EXAMPLES_DIR / "docs").glob("*.py"))
+
+
+class TestDocExamples(parameterized.TestCase):
+    """Runs each documentation example as a standalone script."""
+
+    @parameterized.parameters(*[(p.name,) for p in _DOC_EXAMPLES])
+    def test_doc_example_runs(self, name: str):
+        # Relative model paths in the examples resolve from the examples directory.
+        result = subprocess.run(
+            [sys.executable, f"docs/{name}"],
+            check=False,
+            cwd=_EXAMPLES_DIR,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"docs/{name} failed:\n{result.stdout}\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Source the documentation's code examples from tested Python files and run them in CI, so they can no longer silently drift from the API.